### PR TITLE
Implemented generic error type

### DIFF
--- a/Example/GenericValidatorExample.xcodeproj/project.pbxproj
+++ b/Example/GenericValidatorExample.xcodeproj/project.pbxproj
@@ -253,7 +253,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 		9E3BBBF12FFA1ED47E01A71D /* [CP] Check Pods Manifest.lock */ = {
@@ -268,7 +268,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 		CACF77F8D40B1C1EC773EC80 /* [CP] Copy Pods Resources */ = {

--- a/Example/GenericValidatorExampleTests/CustomUserTypeValidationTests.swift
+++ b/Example/GenericValidatorExampleTests/CustomUserTypeValidationTests.swift
@@ -17,7 +17,7 @@ struct User {
 
 extension User: Validatable {
 
-    func validate(_ functions: [(User) -> ValidationResult]) -> ValidationResult {
+    func validate(_ functions: [(User) -> ValidationResult<ValidationError>]) -> ValidationResult<ValidationError> {
         return functions.map({ f in f(self) }).reduce(ValidationResult.valid) { $0.combine($1) }
     }
 
@@ -30,7 +30,7 @@ class CustomUserTypeValidationTests: XCTestCase {
         let user = User(firstName: "Thibault", lastName: "Klein", age: 26)
         let result = user.validate([isUserNameValid, isUserAdult])
         // When
-        let expectedResult = ValidationResult.valid
+        let expectedResult = ValidationResult<ValidationError>.valid
         // Then
         XCTAssertEqual(result, expectedResult)
     }
@@ -65,7 +65,7 @@ class CustomUserTypeValidationTests: XCTestCase {
         XCTAssertEqual(result, expectedResult)
     }
 
-    private func isUserNameValid(user: User) -> ValidationResult {
+    private func isUserNameValid(user: User) -> ValidationResult<ValidationError> {
         let regexp = "[A-Za-z]+$"
         if user.firstName.evaluate(with: regexp)
             && user.lastName.evaluate(with: regexp) {
@@ -75,7 +75,7 @@ class CustomUserTypeValidationTests: XCTestCase {
         return .invalid([ValidationError.error("The user name is invalid")])
     }
 
-    private func isUserAdult(user: User) -> ValidationResult {
+    private func isUserAdult(user: User) -> ValidationResult<ValidationError> {
         if user.age >= 18 {
             return .valid
         }

--- a/Example/GenericValidatorExampleTests/CustomUserTypeValidationTests.swift
+++ b/Example/GenericValidatorExampleTests/CustomUserTypeValidationTests.swift
@@ -9,6 +9,8 @@
 import XCTest
 @testable import GenericValidator
 
+typealias UserValidationResult = ValidationResult<ValidationError>
+
 struct User {
     let firstName: String
     let lastName: String
@@ -17,7 +19,7 @@ struct User {
 
 extension User: Validatable {
 
-    func validate(_ functions: [(User) -> ValidationResult<ValidationError>]) -> ValidationResult<ValidationError> {
+    func validate(_ functions: [(User) -> UserValidationResult]) -> UserValidationResult {
         return functions.map({ f in f(self) }).reduce(ValidationResult.valid) { $0.combine($1) }
     }
 
@@ -30,7 +32,7 @@ class CustomUserTypeValidationTests: XCTestCase {
         let user = User(firstName: "Thibault", lastName: "Klein", age: 26)
         let result = user.validate([isUserNameValid, isUserAdult])
         // When
-        let expectedResult = ValidationResult<ValidationError>.valid
+        let expectedResult = UserValidationResult.valid
         // Then
         XCTAssertEqual(result, expectedResult)
     }
@@ -40,7 +42,7 @@ class CustomUserTypeValidationTests: XCTestCase {
         let user = User(firstName: "Thibault1", lastName: "Klein", age: 26)
         let result = user.validate([isUserNameValid, isUserAdult])
         // When
-        let expectedResult = ValidationResult.invalid([ValidationError.error("The user name is invalid")])
+        let expectedResult = UserValidationResult.invalid([ValidationError.error("The user name is invalid")])
         // Then
         XCTAssertEqual(result, expectedResult)
     }
@@ -50,7 +52,7 @@ class CustomUserTypeValidationTests: XCTestCase {
         let user = User(firstName: "Thibault", lastName: "Klein@", age: 26)
         let result = user.validate([isUserNameValid, isUserAdult])
         // When
-        let expectedResult = ValidationResult.invalid([ValidationError.error("The user name is invalid")])
+        let expectedResult = UserValidationResult.invalid([ValidationError.error("The user name is invalid")])
         // Then
         XCTAssertEqual(result, expectedResult)
     }
@@ -60,12 +62,12 @@ class CustomUserTypeValidationTests: XCTestCase {
         let user = User(firstName: "Thibault", lastName: "Klein", age: 17)
         let result = user.validate([isUserNameValid, isUserAdult])
         // When
-        let expectedResult = ValidationResult.invalid([ValidationError.error("The user is not an adult")])
+        let expectedResult = UserValidationResult.invalid([ValidationError.error("The user is not an adult")])
         // Then
         XCTAssertEqual(result, expectedResult)
     }
 
-    private func isUserNameValid(user: User) -> ValidationResult<ValidationError> {
+    private func isUserNameValid(user: User) -> UserValidationResult {
         let regexp = "[A-Za-z]+$"
         if user.firstName.evaluate(with: regexp)
             && user.lastName.evaluate(with: regexp) {
@@ -75,7 +77,7 @@ class CustomUserTypeValidationTests: XCTestCase {
         return .invalid([ValidationError.error("The user name is invalid")])
     }
 
-    private func isUserAdult(user: User) -> ValidationResult<ValidationError> {
+    private func isUserAdult(user: User) -> UserValidationResult {
         if user.age >= 18 {
             return .valid
         }

--- a/Example/GenericValidatorExampleTests/TextFieldValidationTests.swift
+++ b/Example/GenericValidatorExampleTests/TextFieldValidationTests.swift
@@ -9,6 +9,8 @@
 import XCTest
 @testable import GenericValidator
 
+typealias TextFieldValidationResult = ValidationResult<ValidationError>
+
 enum ValidationError: Error, Equatable {
     case error(String)
 }
@@ -28,7 +30,7 @@ class TextFieldValidationTests: XCTestCase {
         textField.text = "qwerty"
         let result = textField.validate([isPasswordEmpty])
         // When
-        let expectedResult = ValidationResult<ValidationError>.valid
+        let expectedResult = TextFieldValidationResult.valid
         // Then
         XCTAssertEqual(result, expectedResult)
     }
@@ -39,7 +41,7 @@ class TextFieldValidationTests: XCTestCase {
         textField.text = nil
         let result = textField.validate([isPasswordEmpty])
         // When
-        let expectedResult = ValidationResult.invalid([ValidationError.error("The password is empty")])
+        let expectedResult = TextFieldValidationResult.invalid([ValidationError.error("The password is empty")])
         // Then
         XCTAssertEqual(result, expectedResult)
     }
@@ -50,7 +52,7 @@ class TextFieldValidationTests: XCTestCase {
         textField.text = "abcdefghij123456"
         let result = textField.validate([isPasswordEmpty, isPasswordStrong])
         // When
-        let expectedResult = ValidationResult<ValidationError>.valid
+        let expectedResult = TextFieldValidationResult.valid
         // Then
         XCTAssertEqual(result, expectedResult)
     }
@@ -61,7 +63,7 @@ class TextFieldValidationTests: XCTestCase {
         textField.text = "abcd"
         let result = textField.validate([isPasswordEmpty, isPasswordStrong])
         // When
-        let expectedResult = ValidationResult.invalid([ValidationError.error("The password is too short"),
+        let expectedResult = TextFieldValidationResult.invalid([ValidationError.error("The password is too short"),
                                                        ValidationError.error("The password doesn't contain a digit")])
         // Then
         XCTAssertEqual(result, expectedResult)
@@ -73,7 +75,7 @@ class TextFieldValidationTests: XCTestCase {
         textField.text = "abc12"
         let result = textField.validate([isPasswordEmpty, isPasswordStrong])
         // When
-        let expectedResult = ValidationResult.invalid([ValidationError.error("The password is too short")])
+        let expectedResult = TextFieldValidationResult.invalid([ValidationError.error("The password is too short")])
         // Then
         XCTAssertEqual(result, expectedResult)
     }
@@ -84,12 +86,12 @@ class TextFieldValidationTests: XCTestCase {
         textField.text = "abcueuiziuefjiuzfz"
         let result = textField.validate([isPasswordEmpty, isPasswordStrong])
         // When
-        let expectedResult = ValidationResult.invalid([ValidationError.error("The password doesn't contain a digit")])
+        let expectedResult = TextFieldValidationResult.invalid([ValidationError.error("The password doesn't contain a digit")])
         // Then
         XCTAssertEqual(result, expectedResult)
     }
 
-    private func isPasswordEmpty(password: String) -> ValidationResult<ValidationError> {
+    private func isPasswordEmpty(password: String) -> TextFieldValidationResult {
         if password.isNotEmpty() {
             return .valid
         }
@@ -97,7 +99,7 @@ class TextFieldValidationTests: XCTestCase {
         return .invalid([ValidationError.error("The password is empty")])
     }
 
-    private func isPasswordStrong(password: String) -> ValidationResult<ValidationError> {
+    private func isPasswordStrong(password: String) -> TextFieldValidationResult {
         var errors = [ValidationError]()
 
         if password.characters.count <= 7 {

--- a/Example/GenericValidatorExampleTests/TextFieldValidationTests.swift
+++ b/Example/GenericValidatorExampleTests/TextFieldValidationTests.swift
@@ -9,8 +9,15 @@
 import XCTest
 @testable import GenericValidator
 
-enum ValidationError: Error {
+enum ValidationError: Error, Equatable {
     case error(String)
+}
+
+func ==(lhs: ValidationError, rhs: ValidationError) -> Bool {
+    switch (lhs, rhs) {
+    case (.error(let leftErrorMessage), .error(let rightErrorMessage)):
+        return leftErrorMessage == rightErrorMessage
+    }
 }
 
 class TextFieldValidationTests: XCTestCase {
@@ -21,7 +28,7 @@ class TextFieldValidationTests: XCTestCase {
         textField.text = "qwerty"
         let result = textField.validate([isPasswordEmpty])
         // When
-        let expectedResult = ValidationResult.valid
+        let expectedResult = ValidationResult<ValidationError>.valid
         // Then
         XCTAssertEqual(result, expectedResult)
     }
@@ -43,7 +50,7 @@ class TextFieldValidationTests: XCTestCase {
         textField.text = "abcdefghij123456"
         let result = textField.validate([isPasswordEmpty, isPasswordStrong])
         // When
-        let expectedResult = ValidationResult.valid
+        let expectedResult = ValidationResult<ValidationError>.valid
         // Then
         XCTAssertEqual(result, expectedResult)
     }
@@ -82,7 +89,7 @@ class TextFieldValidationTests: XCTestCase {
         XCTAssertEqual(result, expectedResult)
     }
 
-    private func isPasswordEmpty(password: String) -> ValidationResult {
+    private func isPasswordEmpty(password: String) -> ValidationResult<ValidationError> {
         if password.isNotEmpty() {
             return .valid
         }
@@ -90,7 +97,7 @@ class TextFieldValidationTests: XCTestCase {
         return .invalid([ValidationError.error("The password is empty")])
     }
 
-    private func isPasswordStrong(password: String) -> ValidationResult {
+    private func isPasswordStrong(password: String) -> ValidationResult<ValidationError> {
         var errors = [ValidationError]()
 
         if password.characters.count <= 7 {

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - GenericValidator (0.0.2)
+  - GenericValidator (0.0.3)
 
 DEPENDENCIES:
   - GenericValidator (from `../`)
@@ -9,8 +9,8 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  GenericValidator: 1923638c0fffdaf324592719d2d43352f65be84c
+  GenericValidator: 6832c747557f714c3398cc174651ad8a4d181069
 
 PODFILE CHECKSUM: 32202c54ca54107be3a5d9b8f012fb2a421447e8
 
-COCOAPODS: 1.2.0
+COCOAPODS: 1.2.1

--- a/README.md
+++ b/README.md
@@ -52,7 +52,9 @@ enum ValidationError: Error {
     case error(String)
 }
 
-func isCVCValid(text: String) -> ValidationResult {
+typealias CVCValidationResult = ValidationResult<ValidationError>
+
+func isCVCValid(text: String) -> CVCValidationResult {
     let regexp = "^[0-9]{3,4}$"
     if text.evaluate(with: regexp) {
         return .valid
@@ -84,15 +86,17 @@ struct User {
     let age: Int
 }
 
+typealias UserValidationResult = ValidationResult<ValidationError>
+
 extension User: Validatable {
 
-    func validate(_ functions: [(User) -> ValidationResult]) -> ValidationResult {
-		return functions.map({ f in f(self) }).reduce(ValidationResult.valid) { $0.combine($1) }
+    func validate(_ functions: [(User) -> UserValidationResult]) -> UserValidationResult {
+		return functions.map({ f in f(self) }).reduce(UserValidationResult.valid) { $0.combine($1) }
     }
 
 }
 
-func isUserNameValid(user: User) -> ValidationResult {
+func isUserNameValid(user: User) -> UserValidationResult {
     let regexp = "[A-Za-z]+$"
     if user.firstName.evaluate(with: regexp)
         && user.lastName.evaluate(with: regexp) {

--- a/Sources/Extensions/UITextField+Validatable.swift
+++ b/Sources/Extensions/UITextField+Validatable.swift
@@ -12,7 +12,7 @@ public extension UITextField {
     ///
     /// - Parameter functions: The functions to validate.
     /// - Returns: `true` if and only if all the functions validated.
-    public func validate(_ functions: [(String) -> ValidationResult]) -> ValidationResult {
+    public func validate<T: Error & Equatable>(_ functions: [(String) -> ValidationResult<T>]) -> ValidationResult<T> {
         return functions
             .map({ f in f(self.text ?? "") })
             .reduce(ValidationResult.valid) { $0.combine($1) }

--- a/Sources/Validatable.swift
+++ b/Sources/Validatable.swift
@@ -10,11 +10,12 @@
 public protocol Validatable {
 
     associatedtype T
+    associatedtype Error: Swift.Error, Equatable
 
     /// Validates the functions passed as the parameter.
     ///
     /// - Parameter functions: The functions to validate.
     /// - Returns: The validation result.
-    func validate(_ functions: [(T) -> ValidationResult]) -> ValidationResult
+    func validate(_ functions: [(T) -> ValidationResult<Error>]) -> ValidationResult<Error>
 
 }

--- a/Sources/ValidationResult.swift
+++ b/Sources/ValidationResult.swift
@@ -10,10 +10,10 @@
 ///
 /// - valid: Indicates that the validation passed.
 /// - invalid: Indicates that the validation didn't pass, with a list of associated errors.
-public enum ValidationResult {
+public enum ValidationResult<T: Error & Equatable> {
 
     case valid
-    case invalid([Error])
+    case invalid([T])
 
     /// Returns `true` if and only if the validation result is valid.
     public var isValid: Bool {
@@ -41,12 +41,12 @@ public enum ValidationResult {
 
 extension ValidationResult: Equatable { }
 
-public func ==(lhs: ValidationResult, rhs: ValidationResult) -> Bool {
+public func ==<T: Error & Equatable>(lhs: ValidationResult<T>, rhs: ValidationResult<T>) -> Bool {
     switch (lhs, rhs) {
     case (.valid, .valid):
         return true
-    case (.invalid(_), .invalid(_)):
-        return true
+    case (.invalid(let leftErrors), .invalid(let rightErrors)):
+        return leftErrors == rightErrors
     default:
         return false
     }


### PR DESCRIPTION
By adding a generic error type that also conforms to the `Equatable` protocol, we can make sure the validation result can be correctly tested if the validation returns errors.

Before, we couldn't test if the returned errors where matching the expected ones.