### PR TITLE
Updated email regex to support plus and period in middle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_install:
 #- pod install --project-directory=Example
 - gem install bundler
 - bundle install
-- pod repo update
+- pod repo update --silent
 - pod install --project-directory=Example
 script:
 - set -o pipefail && xcodebuild test -workspace Example/GenericValidatorExample.xcworkspace -scheme GenericValidatorExampleTests -destination 'platform=iOS Simulator,name=iPhone 6,OS=9.2' | xcpretty

--- a/Example/GenericValidatorExampleTests/StringEvaluationTests.swift
+++ b/Example/GenericValidatorExampleTests/StringEvaluationTests.swift
@@ -96,9 +96,14 @@ class StringEvaluationTests: XCTestCase {
         XCTAssertTrue(text.isEmailValid())
     }
 
-    func test_whenTextIsInvalidEmail_withPlusCharacter() {
+    func test_whenTextIsValidEmail_withPlusCharacter() {
         let text = "marc+test@msn.com"
-        XCTAssertFalse(text.isEmailValid())
+        XCTAssertTrue(text.isEmailValid())
+    }
+
+    func test_whenTextIsValidEmail_withPeriodCharacter() {
+        let text = "marc.test@msn.com"
+        XCTAssertTrue(text.isEmailValid())
     }
 
     func test_whenTextIsInvalidEmail_withUnderscoreCharacter() {

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - GenericValidator (0.0.3)
+  - GenericValidator (0.0.4)
 
 DEPENDENCIES:
   - GenericValidator (from `../`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  GenericValidator: 6832c747557f714c3398cc174651ad8a4d181069
+  GenericValidator: 0d362d25c6b072b874513f634b1f107bcadfa337
 
 PODFILE CHECKSUM: 32202c54ca54107be3a5d9b8f012fb2a421447e8
 

--- a/Sources/Extensions/String+Evaluatable.swift
+++ b/Sources/Extensions/String+Evaluatable.swift
@@ -69,13 +69,12 @@ public extension String {
     ///
     /// - Returns: `true` if and only if the text is a valid email.
     func isEmailValid() -> Bool {
-        let regexp = "^[_A-Za-z0-9-\\+]+(\\.[_A-Za-z0-9-]+)*@[A-Za-z0-9-]+(\\.[A-Za-z0-9]+)*(\\.[A-Za-z]{2,})$"
-        let letters = CharacterSet.letters
-        let digits = CharacterSet.decimalDigits
-        let firstChar = unicodeScalars.first!
+        guard let firstChar = unicodeScalars.first else {
+            return false
+        }
         
-        return evaluate(with: regexp)
-            && (letters.contains(firstChar) || digits.contains(firstChar))
+        let regexp = "^[_A-Za-z0-9-\\+]+(\\.[_A-Za-z0-9-]+)*@[A-Za-z0-9-]+(\\.[A-Za-z0-9]+)*(\\.[A-Za-z]{2,})$"
+        return evaluate(with: regexp) && firstChar.isAlphaNumeric()
     }
 
 }

--- a/Sources/Extensions/String+Evaluatable.swift
+++ b/Sources/Extensions/String+Evaluatable.swift
@@ -69,8 +69,13 @@ public extension String {
     ///
     /// - Returns: `true` if and only if the text is a valid email.
     func isEmailValid() -> Bool {
-        let regexp = "[A-Z0-9a-z]+[A-Z0-9a-z._-]?@(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\\.)+[a-zA-Z]{2,6}\\.?$"
+        let regexp = "^[_A-Za-z0-9-\\+]+(\\.[_A-Za-z0-9-]+)*@[A-Za-z0-9-]+(\\.[A-Za-z0-9]+)*(\\.[A-Za-z]{2,})$"
+        let letters = CharacterSet.letters
+        let digits = CharacterSet.decimalDigits
+        let firstChar = unicodeScalars.first!
+        
         return evaluate(with: regexp)
+            && (letters.contains(firstChar) || digits.contains(firstChar))
     }
 
 }

--- a/Sources/Extensions/UnicodeScalar+Helpers.swift
+++ b/Sources/Extensions/UnicodeScalar+Helpers.swift
@@ -1,0 +1,32 @@
+//
+//  UnicodeScalar+Helpers.swift
+//  GenericValidator
+//
+//  Created by Harlan Kellaway on 7/12/17.
+//  Copyright © 2017 Prolific Interactive. All rights reserved.
+//
+
+internal extension UnicodeScalar {
+    
+    /// Whether the scalar is either a letter or a digit.
+    ///
+    /// - Returns: True if the scalar is alphanumeric, false otherwise.
+    func isAlphaNumeric() -> Bool {
+        return isLetter() || isDigit()
+    }
+    
+    /// Whether the scalar is a letter.
+    ///
+    /// - Returns: True if the scalar is a letter, false otherwise.
+    func isLetter() -> Bool {
+        return CharacterSet.letters.contains(self)
+    }
+    
+    /// Whether the scalar is a digit.
+    ///
+    /// - Returns: True if the scalar is a digit, false otherwise.
+    func isDigit() -> Bool {
+        return CharacterSet.decimalDigits.contains(self)
+    }
+    
+}


### PR DESCRIPTION
I found the previous regex did not cover including a `+` symbol in the email (e.g. user+20@prolificinteractive.com) - updated to the Swift regex example found at http://emailregex.com